### PR TITLE
waterhouse-landing-8: correct studio count 25 → 15+ site-wide

### DIFF
--- a/docs/SEO_SPEC.md
+++ b/docs/SEO_SPEC.md
@@ -3,7 +3,7 @@
 **Site:** https://waterhousestudios.nl
 **Repo:** `waterhouse-landing` (SvelteKit 2 + Svelte 5, `adapter-static`, GitHub Pages behind Cloudflare)
 **Date:** 2026-07-03
-**Business:** Music studio rental (25 acoustically designed studios), ateliers, artist residency (15+ residents, growing), in-person events (capacity ~120), and online radio via Twitch (`twitch.tv/waterhousestudios`). Location: Danzigerkade 1, 1013 AP Amsterdam (Houthaven).
+**Business:** Music studio rental (15+ acoustically designed studios), ateliers, artist residency (15+ residents, growing), in-person events (capacity ~120), and online radio via Twitch (`twitch.tv/waterhousestudios`). Location: Danzigerkade 1, 1013 AP Amsterdam (Houthaven).
 
 ---
 
@@ -96,7 +96,7 @@ Add `src/routes/sitemap.xml/+server.ts` with `export const prerender = true`, em
 - **`og:image` / `twitter:image`:** create a 1200×630 branded card (the `og-image` skill in this repo can generate it from the existing design system), place at `static/og.png`, reference with absolute URL. Per-page overrides for events.
 - **Unique title + description per route.** Homepage title should carry the money keywords, e.g.:
   - Title: `Waterhouse Studios — Music Studio Rental, Events & Online Radio in Amsterdam`
-  - Description: `25 acoustically designed music studios for rent in Amsterdam (Houthaven). Shared studios from €30/hr, private 24/7 studios, ateliers, live events and weekly online radio from Amsterdam's DJ community.`
+  - Description: `15+ acoustically designed music studios for rent in Amsterdam (Houthaven). Shared studios from €30/hr, private 24/7 studios, ateliers, live events and weekly online radio from Amsterdam's DJ community.`
 - Recommended pattern (SvelteKit official): return SEO fields from each page's `load`, render once in root layout `<svelte:head>`.
 
 ### 3.5 Bug fixes
@@ -132,8 +132,8 @@ Delete `SEOContent.svelte` usage once Phase 1 pages exist (do it in the same rel
 
 ### 4.2 Content rules for every page (from Google's guide + GEO research)
 - Exactly one `<h1>` containing the page's primary query phrasing; H2s phrased as questions where natural.
-- **Lead with a direct, self-contained 40–60 word answer** ("Waterhouse Studios rents 25 acoustically designed music studios in Amsterdam's Houthaven, from €30/hour shared sessions to €1,100/month private 24/7 studios…") — this is what snippets and AI answers extract.
-- **Specific numbers everywhere:** 25 studios, 15+ residents, 120-person event space, 24-bit/96 kHz, prices, address. Stats lift AI citation rates ~37–40% (Princeton GEO).
+- **Lead with a direct, self-contained 40–60 word answer** ("Waterhouse Studios rents 15+ acoustically designed music studios in Amsterdam's Houthaven, from €30/hour shared sessions to €1,100/month private 24/7 studios…") — this is what snippets and AI answers extract.
+- **Specific numbers everywhere:** 15+ studios, 15+ residents, 120-person event space, 24-bit/96 kHz, prices, address. Stats lift AI citation rates ~37–40% (Princeton GEO).
 - Semantic HTML (`<main>`, `<nav>`, `<article>`), descriptive alt text, descriptive internal anchor text.
 - Visible **"Last updated"** dates on pages that change.
 - Written for humans in Waterhouse's voice — no keyword stuffing (it measurably *reduces* AI visibility).
@@ -163,7 +163,7 @@ No schema exists today. Implement JSON-LD (Google's only supported-everywhere fo
       "@type": "MusicVenue",
       "@id": "https://waterhousestudios.nl/#venue",
       "name": "Waterhouse Studios",
-      "description": "Music studio rental, artist residency, events and online radio in Amsterdam. 25 acoustically designed studios built by DJs and musicians for creators.",
+      "description": "Music studio rental, artist residency, events and online radio in Amsterdam. 15+ acoustically designed studios built by DJs and musicians for creators.",
       "url": "https://waterhousestudios.nl",
       "logo": "https://waterhousestudios.nl/logo.png",
       "image": "https://waterhousestudios.nl/og.png",

--- a/src/lib/SiteFooter.svelte
+++ b/src/lib/SiteFooter.svelte
@@ -11,8 +11,8 @@
 		<div class="md:col-span-2">
 			<img src="/logo.png" width="160" height="40" alt="Waterhouse Studios" class="mb-3" />
 			<p class="max-w-sm text-sm opacity-70">
-				{SITE.facts.studioCount} acoustically designed music studios, ateliers, an artist residency,
-				live events and weekly online radio — built by DJs and musicians for creators in Amsterdam.
+				{SITE.facts.studioCountLabel} studios & ateliers, an artist residency, live events and weekly
+				online radio — built by DJs and musicians for creators in Amsterdam.
 			</p>
 		</div>
 

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -8,7 +8,7 @@ export const SITE = {
 	url: 'https://waterhousestudios.nl',
 	tagline: 'Music studios, events & online radio in Amsterdam',
 	description:
-		'Waterhouse Studios rents 25 acoustically designed music studios in Amsterdam (Houthaven), from €30/hour shared sessions to €1,100/month private 24/7 studios. Home to an artist residency, live events and a weekly online radio stream of Amsterdam DJs and artists.',
+		'Waterhouse Studios rents 15+ acoustically designed music studios in Amsterdam (Houthaven), from €30/hour shared sessions to €1,100/month private 24/7 studios. Home to an artist residency, live events and a weekly online radio stream of Amsterdam DJs and artists.',
 	email: 'info@waterhousestudios.nl',
 	// Physical location — Houthaven / western harbour, Amsterdam.
 	address: {
@@ -25,7 +25,8 @@ export const SITE = {
 	ogImage: '/og.png',
 	// Key facts, reused across pages and schema so numbers never drift.
 	facts: {
-		studioCount: 25,
+		// Rendered as a string so copy can read "15+"; keep every call site grammatical.
+		studioCountLabel: '15+',
 		eventCapacity: 120,
 		residentCount: 15,
 		audio: '24-bit / 96 kHz'

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -413,7 +413,7 @@
 		Waterhouse Studios — music studio rental, events &amp; online radio in Amsterdam
 	</h1>
 	<p class="mt-1 text-base opacity-60">
-		{SITE.facts.studioCount} acoustically designed studios in the Houthaven ·
+		{SITE.facts.studioCountLabel} acoustically designed studios in the Houthaven ·
 		<a href="/studios" class="hover:text-amber underline">rent a studio</a> ·
 		<a href="/radio" class="hover:text-amber underline">live radio</a> ·
 		<a href="/events" class="hover:text-amber underline">events</a>

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -10,7 +10,7 @@
 <Seo
 	title="About Waterhouse Studios Amsterdam"
 	image="/og/about.png"
-	description="Waterhouse Studios is a music studio, artist residency, event space and online radio in Amsterdam's Houthaven — {SITE.facts.studioCount} acoustically designed studios built by DJs and musicians for creators."
+	description="Waterhouse Studios is a music studio, artist residency, event space and online radio in Amsterdam's Houthaven — {SITE.facts.studioCountLabel} acoustically designed studios built by DJs and musicians for creators."
 />
 <JsonLd schema={graph(breadcrumb([{ name: 'About', path: '/about' }]))} />
 
@@ -27,7 +27,7 @@
 		<p class="mb-6 text-xl leading-relaxed">
 			Waterhouse Studios is a launchpad built by DJs and musicians for creators in Amsterdam's
 			Houthaven. Everything we offer is tailored to the needs of music creators and the people working
-			in the music industry: {SITE.facts.studioCount} acoustically designed studios, ateliers, an
+			in the music industry: {SITE.facts.studioCountLabel} acoustically designed studios, ateliers, an
 			artist residency, an event space for up to {SITE.facts.eventCapacity} people, and a weekly online
 			radio stream — all in one place.
 		</p>

--- a/src/routes/studios/+page.svelte
+++ b/src/routes/studios/+page.svelte
@@ -25,7 +25,7 @@
 <Seo
 	title="Music Studio Rental in Amsterdam — Waterhouse Studios"
 	image="/og/studios.png"
-	description="Rent a music studio in Amsterdam. {SITE.facts.studioCount} acoustically designed studios in the Houthaven — shared sessions from €{PRICING.sharedHourly}/hour, private 24/7 solo studios €{PRICING.soloMonthly}/month. Recording, production and streaming, {SITE.facts.audio}."
+	description="Rent a music studio in Amsterdam. {SITE.facts.studioCountLabel} acoustically designed studios in the Houthaven — shared sessions from €{PRICING.sharedHourly}/hour, private 24/7 solo studios €{PRICING.soloMonthly}/month. Recording, production and streaming, {SITE.facts.audio}."
 />
 <JsonLd schema={graph(studioServiceSchema(), breadcrumb([{ name: 'Studios', path: '/studios' }]))} />
 
@@ -40,7 +40,7 @@
 		<h1 class="mb-4 text-5xl md:text-7xl">Music studio rental in Amsterdam</h1>
 
 		<p class="mb-8 max-w-3xl text-xl leading-relaxed">
-			Waterhouse Studios rents {SITE.facts.studioCount} acoustically designed music studios in Amsterdam's
+			Waterhouse Studios rents {SITE.facts.studioCountLabel} acoustically designed music studios in Amsterdam's
 			Houthaven, from €{PRICING.sharedHourly}/hour shared sessions to €{PRICING.soloMonthly}/month private
 			24/7 studios. Each room is custom-designed by industry professionals for recording, producing,
 			mixing and streaming at {SITE.facts.audio} — built by creators, for creators.


### PR DESCRIPTION
## Summary

The site claimed **"25 acoustically designed music studios"** — a factually inaccurate number that appeared across marketing copy, meta descriptions, and JSON-LD schema (where a wrong number actively hurts trust). This corrects it to the **"15+ studios & ateliers"** framing site-wide.

## Changes

- **`src/lib/site.ts`** — replaced `facts.studioCount: 25` with `facts.studioCountLabel: '15+'` (a string, so every call site reads "15+" grammatically); corrected the hardcoded `25` in the `description` string.
- **`src/lib/SiteFooter.svelte`** — footer now reads: *"15+ studios & ateliers, an artist residency, live events and weekly online radio — built by DJs and musicians for creators in Amsterdam."*
- **`src/routes/+page.svelte`** — homepage hero subline.
- **`src/routes/studios/+page.svelte`** — meta description + body copy.
- **`src/routes/about/+page.svelte`** — meta description + body copy.
- **JSON-LD** — the venue schema `description` flows from `SITE.description`, now corrected (no hardcoded `25`).
- **`docs/SEO_SPEC.md`** — updated the canonical "25 studios" fact in 5 places so the spec doesn't re-introduce the wrong number. Left the unrelated "25 MB of JPGs" and "≥25 Google reviews" references untouched (not studio counts).

## Verification

- `grep -rn` finds no remaining "25 studios" / "25 acoustically designed" reference in `src/` or `docs/`.
- `bun run build` passes.
- `svelte-check` errors are pre-existing (identical count on the base branch; none in the edited files).

Task: waterhouse-landing-8

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HnK9b2gV9GDcWsyPECbgtF