### PR TITLE
waterhouse-landing-11: lift hero header above draping cables (z-index)

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -408,7 +408,7 @@
 	onOpenAtelier={() => (isModalOpen = 'offices')}
 />
 
-<header class="font-jersey text-secondary container mx-auto px-4 text-center">
+<header class="font-jersey text-secondary container relative z-10 mx-auto px-4 text-center">
 	<h1 class="text-2xl leading-tight md:text-3xl">
 		Waterhouse Studios — music studio rental, events &amp; online radio in Amsterdam
 	</h1>


### PR DESCRIPTION
## Problem
On the homepage, the decorative `.cables-svg` audio cables that drape over the top of the sampler machine painted **on top of** the hero heading and subtitle, cutting through "Waterhouse Studios — music studio rental, events & online radio in Amsterdam" and hurting readability.

## Cause
The cables are `position: absolute; bottom: calc(100% - 8px)` inside `.machine-cabinet` with `z-index: 0`, so they extend up into the hero region. The hero `<header>` was in normal flow with no stacking context, so the positioned cables rendered above it.

## Fix
Add `relative z-10` to the hero `<header>`, giving it its own stacking context above the cables' `z-index: 0`. One-line change.

## Verification
- `bun run build` passes.
- Headless Chrome screenshot at 1280px: heading and subtitle now render fully legible **in front of** all four cables (black/red/yellow/blue); cables still drape correctly over the machine (gallery keeps `z-index: 1`, machine body stays behind).
- Cables are `hidden md:block`, so mobile is unaffected.

Task: waterhouse-landing-11

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)