### PR TITLE
waterhouse-landing-14: legible hero + nav text where cables cross

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -31,3 +31,28 @@ body {
 .midi {
 	@apply shadow-flat hover:shadow-hover hover:translate-reset translate-adjust active:shadow-hover active:translate-reset rounded border-2 border-black transition-all;
 }
+
+/*
+ * Paper-colored glyph halo (knockout) — makes wires appear to duck behind
+ * each character with a clean light gap, so hero + nav text stays legible
+ * where a cable (esp. the black one) crosses it. Wires stay fully visible;
+ * no boxy panel. Suits the pixel display font (font-jersey).
+ */
+.hero-legible {
+	paint-order: stroke fill;
+	-webkit-text-stroke: 3px var(--color-primary); /* #faf6f6 paper */
+	text-shadow:
+		0 0 4px var(--color-primary),
+		0 0 4px var(--color-primary),
+		0 0 8px var(--color-primary);
+}
+
+/* Lighter ring for smaller supporting text (subtitle, nav links). */
+.hero-legible-sm {
+	paint-order: stroke fill;
+	-webkit-text-stroke: 2px var(--color-primary);
+	text-shadow:
+		0 0 3px var(--color-primary),
+		0 0 3px var(--color-primary),
+		0 0 6px var(--color-primary);
+}

--- a/src/lib/Nav.svelte
+++ b/src/lib/Nav.svelte
@@ -10,13 +10,13 @@
 </script>
 
 <div
-	class="font-jersey container mx-auto hidden h-12 items-center justify-between px-4 text-xl md:mb-10 md:flex"
+	class="font-jersey relative z-10 container mx-auto hidden h-12 items-center justify-between px-4 text-xl md:mb-10 md:flex"
 >
 	<button class="w-16 transition-all hover:scale-110" onclick={onOpenAbout}>
 		<!-- <MaskedLogoShader shader={shaderConfigRainbow} /> -->
-		<img src="/logo.svg" width="100px" alt="logo" />
+		<img src="/logo.svg" width="100px" alt="logo" class="logo-legible" />
 	</button>
-	<div class="flex items-center gap-2">
+	<div class="hero-legible-sm flex items-center gap-2">
 		<button class="cursor-pointer transition-all hover:scale-110" onclick={onOpenStudio}
 			>rent a studio</button
 		>
@@ -27,8 +27,16 @@
 		<span>|</span>
 		<a
 			href="https://app.waterhousestudios.nl"
-			class="cursor-pointer text-sm opacity-40 transition-all hover:opacity-100"
-			>login</a
+			class="cursor-pointer text-sm opacity-40 transition-all hover:opacity-100">login</a
 		>
 	</div>
 </div>
+
+<style>
+	/* Paper halo so the solid-black logo reads cleanly where a cable crosses it.
+	   text-shadow can't touch an <img>, so use a drop-shadow filter on the shape. */
+	.logo-legible {
+		filter: drop-shadow(0 0 3px var(--color-primary)) drop-shadow(0 0 3px var(--color-primary))
+			drop-shadow(0 0 5px var(--color-primary));
+	}
+</style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -409,10 +409,10 @@
 />
 
 <header class="font-jersey text-secondary container relative z-10 mx-auto px-4 text-center">
-	<h1 class="text-2xl leading-tight md:text-3xl">
+	<h1 class="hero-legible text-2xl leading-tight md:text-3xl">
 		Waterhouse Studios — music studio rental, events &amp; online radio in Amsterdam
 	</h1>
-	<p class="mt-1 text-base opacity-60">
+	<p class="hero-legible-sm mt-1 text-base opacity-60">
 		{SITE.facts.studioCountLabel} acoustically designed studios in the Houthaven ·
 		<a href="/studios" class="hover:text-amber underline">rent a studio</a> ·
 		<a href="/radio" class="hover:text-amber underline">live radio</a> ·


### PR DESCRIPTION
## Summary
Follow-up to #11 (PR #13). The hero heading, subtitle, and top-right nav now sit **in front** of the draping audio cables, but a cable crossing a glyph — worst case a **black cable over black text** — was still hard to read, and the nav (a separate component #11 didn't touch) was still covered.

## Approach — paper-colored glyph halo (knockout)
Chose the recommended knockout over the frosted panel because it keeps every wire fully visible with no boxy band and suits the pixel display font.

- Added shared `.hero-legible` / `.hero-legible-sm` classes in `src/app.css`: `paint-order: stroke fill` + `-webkit-text-stroke` + soft `text-shadow`, all in `--color-primary` (#faf6f6 paper). Wires appear to duck behind each character with a clean light gap.
- Applied `.hero-legible` to the hero `<h1>` and `.hero-legible-sm` to the subtitle in `src/routes/+page.svelte`.
- Nav (`src/lib/Nav.svelte`): lifted the container to `relative z-10` (above the cables' `z-index: 0`, mirroring #11's header fix) and applied `.hero-legible-sm` to the links. The logo is a solid-black `<img>` — `text-shadow` can't touch an image, so it gets an equivalent paper `drop-shadow` filter.

## Verification
- `bun run build` passes; confirmed the new classes are emitted in the built CSS.
- Rendered the page headless (Chrome, 1280×900 @2x) and zoomed into both worst-contrast bands: the hero heading reads cleanly where the red/yellow/blue cables cross, and the nav reads cleanly where the **black** cable crosses "studio". Cables remain fully visible and draping over the machine.
- Pre-existing lint (prettier style across 39 untouched files) and `svelte-check` (`implicitly any` in existing handlers) issues are unrelated to this change.

Desktop-focused (cables + nav are `hidden md:*`); mobile is visually unchanged (paper halo on paper background is invisible with no cables present).

Task: waterhouse-landing-14
Closes #14