### PR TITLE
waterhouse-landing-16: swap hero sampler screen for live Twitch embed

### DIFF
--- a/src/lib/TwitchEmbed.svelte
+++ b/src/lib/TwitchEmbed.svelte
@@ -1,14 +1,21 @@
 <script lang="ts">
 	// Live Twitch player that stands in for the hero sampler screen while the
-	// waterhousestudios stream is on air. Mirrors the embed pattern used on the
-	// /radio page: autoplay requires `muted=true`, and Twitch needs every host
-	// domain declared as a `parent` (localhost included for local preview).
-	const parents = ['waterhousestudios.nl', 'localhost'];
-	const embedSrc =
-		`https://player.twitch.tv/?channel=waterhousestudios&muted=true&` +
-		parents.map((p) => `parent=${p}`).join('&');
+	// stream is on air. Mirrors the embed pattern used on the /radio page:
+	// autoplay requires `muted=true`, and Twitch needs every host domain declared
+	// as a `parent` (localhost included for local preview). `parent` is the host
+	// domain, not the channel, so it stays fixed while `channel` follows the
+	// status payload.
+	let {
+		channel = undefined,
+		title = undefined,
+		viewers = undefined
+	}: { channel?: string; title?: string; viewers?: number } = $props();
 
-	let { title = undefined, viewers = undefined }: { title?: string; viewers?: number } = $props();
+	const parents = ['waterhousestudios.nl', 'localhost'];
+	const embedSrc = $derived(
+		`https://player.twitch.tv/?channel=${channel || 'waterhousestudios'}&muted=true&` +
+			parents.map((p) => `parent=${p}`).join('&')
+	);
 </script>
 
 <div class="lcd relative w-full overflow-hidden rounded">

--- a/src/lib/TwitchEmbed.svelte
+++ b/src/lib/TwitchEmbed.svelte
@@ -5,14 +5,15 @@
 	// stream is on air. `parent` is the host domain (not the channel), so it
 	// stays fixed while `channel` follows the status payload.
 	//
-	// Chrome blocks *unmuted* autoplay, so the player starts muted+autoplay. To
-	// offer sound we use the Twitch Player JS SDK: `player.setMuted(false)` called
-	// inside a user click gesture is allowed, and — unlike swapping the iframe
-	// `src` — it unmutes the *existing* stream without reloading/reconnecting.
+	// The player starts muted+autoplay (Chrome plays muted video without a
+	// gesture; on mobile it may stay paused). We use the Twitch Player JS SDK so a
+	// single tap on our own full-area overlay can start + unmute the *existing*
+	// stream in place (play + setMuted, no reload/reconnect) — the user never has
+	// to hunt for Twitch's own buried play/unmute controls.
 	//
 	// FAIL-SAFE: if the SDK script fails to load or `Twitch.Player` is
-	// unavailable, we fall back to a plain muted iframe (the original embed), so
-	// the feature can never break the hero.
+	// unavailable, we fall back to a plain muted+autoplay iframe (the original
+	// embed), so the feature can never break the hero.
 	let {
 		channel = undefined,
 		title = undefined,
@@ -29,10 +30,13 @@
 	);
 
 	// 'loading' — SDK in flight, target div mounted so the player has a home.
-	// 'sdk'     — SDK player created; the unmute overlay is available.
+	// 'sdk'     — SDK player created; the tap-to-watch overlay is available.
 	// 'fallback'— SDK unavailable; render the plain muted iframe instead.
 	let status = $state<'loading' | 'sdk' | 'fallback'>('loading');
-	let muted = $state(true);
+	// Full-area overlay is shown until the first tap. On mobile muted autoplay
+	// may not start, leaving the player paused behind Twitch's own chrome; the
+	// overlay is our single clean tap target that starts + unmutes in one gesture.
+	let interacted = $state(false);
 	let playerEl = $state<HTMLDivElement>();
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	let player: any = null;
@@ -92,13 +96,15 @@
 		};
 	});
 
-	function unmute() {
+	function activate() {
 		if (!player) return;
-		// The video is already playing (muted autoplay), so this click only needs
-		// to add sound — unmute the existing stream in place, no reload, no play().
+		// One user gesture starts everything in place (no reload): play() covers
+		// mobile where muted autoplay never started (harmless no-op on desktop
+		// where it's already playing); setMuted(false)+setVolume add sound.
+		player.play();
 		player.setMuted(false);
 		player.setVolume(0.5);
-		muted = false;
+		interacted = true;
 	}
 </script>
 
@@ -116,20 +122,25 @@
 			<div bind:this={playerEl} class="player-target"></div>
 		{/if}
 
-		{#if status === 'sdk' && muted}
-			<button class="unmute-btn" onclick={unmute} aria-label="Tap to unmute the live stream">
-				<svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true">
-					<path
-						fill="currentColor"
-						d="M3 9v6h4l5 5V4L7 9H3zm13.5 3a4.5 4.5 0 0 0-2.5-4.03v8.06A4.5 4.5 0 0 0 16.5 12zM14 3.23v2.06a7 7 0 0 1 0 13.42v2.06A9 9 0 0 0 14 3.23z"
-					/>
-				</svg>
-				<span>tap to unmute</span>
+		{#if status === 'sdk' && !interacted}
+			<button
+				class="tap-overlay"
+				onclick={activate}
+				aria-label="Tap to watch the live stream with sound"
+			>
+				<span class="tap-inner">
+					<span class="tap-icon" aria-hidden="true">
+						<svg viewBox="0 0 24 24" width="30" height="30">
+							<path fill="currentColor" d="M8 5v14l11-7z" />
+						</svg>
+					</span>
+					<span class="tap-label">tap to watch with sound</span>
+				</span>
 			</button>
 		{/if}
 	</div>
 	<div
-		class="lcd-hud pointer-events-none absolute inset-x-0 top-0 z-20 flex items-center justify-between p-2 text-[0.6rem] tracking-[0.18em] md:p-3 md:text-xs"
+		class="lcd-hud pointer-events-none absolute inset-x-0 top-0 z-40 flex items-center justify-between p-2 text-[0.6rem] tracking-[0.18em] md:p-3 md:text-xs"
 	>
 		<span class="flex items-center gap-1.5">
 			<span class="led-live"></span>
@@ -200,43 +211,67 @@
 			opacity: 0.35;
 		}
 	}
-	/* Unmute affordance in the sampler/LCD aesthetic — amber, glowing, monospace. */
-	.unmute-btn {
+	/* Full-area tap target over the whole video — one clean control of ours that
+	   sits above Twitch's cluttered chrome and starts + unmutes in a single tap.
+	   Sampler/LCD aesthetic: darkened video, amber glowing play prompt. */
+	.tap-overlay {
 		position: absolute;
-		left: 50%;
-		bottom: 12px;
-		transform: translateX(-50%);
+		inset: 0;
 		z-index: 30;
 		pointer-events: auto;
-		display: inline-flex;
-		align-items: center;
-		gap: 8px;
-		padding: 8px 16px;
-		border: 1.5px solid rgba(255, 163, 64, 0.7);
-		border-radius: 999px;
-		background: rgba(6, 8, 9, 0.82);
+		display: grid;
+		place-items: center;
+		width: 100%;
+		height: 100%;
+		margin: 0;
+		padding: 0;
+		border: 0;
+		cursor: pointer;
+		/* Fairly opaque so Twitch's own chrome (Follow/Subscribe/play) is masked and
+		   our prompt reads as the single thing to tap. */
+		background: radial-gradient(
+			ellipse at center,
+			rgba(6, 8, 9, 0.82) 0%,
+			rgba(6, 8, 9, 0.95) 100%
+		);
 		color: #ffa340;
 		font-family: var(--font-jersey);
-		font-size: 0.8rem;
-		letter-spacing: 0.14em;
+		text-shadow:
+			0 0 6px rgba(255, 140, 26, 0.6),
+			0 0 12px rgba(255, 140, 26, 0.3);
+		transition: background 0.15s ease;
+	}
+	.tap-overlay:hover {
+		background: radial-gradient(ellipse at center, rgba(6, 8, 9, 0.72) 0%, rgba(6, 8, 9, 0.9) 100%);
+	}
+	.tap-inner {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 12px;
+		padding: 0 16px;
+		text-align: center;
+	}
+	.tap-icon {
+		display: grid;
+		place-items: center;
+		width: 64px;
+		height: 64px;
+		padding-left: 4px; /* optically center the play triangle */
+		border: 2px solid rgba(255, 163, 64, 0.85);
+		border-radius: 50%;
+		background: rgba(6, 8, 9, 0.55);
+		box-shadow:
+			0 0 0 1px rgba(0, 0, 0, 0.4),
+			0 0 22px rgba(255, 140, 26, 0.4),
+			inset 0 0 16px rgba(255, 140, 26, 0.2);
+	}
+	.tap-overlay:active .tap-icon {
+		transform: translateY(1px);
+	}
+	.tap-label {
+		font-size: 0.95rem;
+		letter-spacing: 0.16em;
 		text-transform: uppercase;
-		cursor: pointer;
-		text-shadow: 0 0 6px rgba(255, 140, 26, 0.5);
-		box-shadow:
-			0 0 0 1px rgba(0, 0, 0, 0.4),
-			0 0 16px rgba(255, 140, 26, 0.35);
-		transition:
-			background 0.15s ease,
-			box-shadow 0.15s ease,
-			transform 0.05s ease;
-	}
-	.unmute-btn:hover {
-		background: rgba(16, 22, 29, 0.92);
-		box-shadow:
-			0 0 0 1px rgba(0, 0, 0, 0.4),
-			0 0 22px rgba(255, 140, 26, 0.55);
-	}
-	.unmute-btn:active {
-		transform: translateX(-50%) translateY(1px);
 	}
 </style>

--- a/src/lib/TwitchEmbed.svelte
+++ b/src/lib/TwitchEmbed.svelte
@@ -2,14 +2,17 @@
 	import { onMount } from 'svelte';
 
 	// Live Twitch player that stands in for the hero sampler screen while the
-	// stream is on air. `parent` is the host domain (not the channel), so it
-	// stays fixed while `channel` follows the status payload.
+	// stream is on air. `parent` is the host domain (not the channel), so it stays
+	// fixed while `channel` follows the status payload.
 	//
-	// The player starts muted+autoplay (Chrome plays muted video without a
-	// gesture; on mobile it may stay paused). We use the Twitch Player JS SDK so a
-	// single tap on our own full-area overlay can start + unmute the *existing*
-	// stream in place (play + setMuted, no reload/reconnect) — the user never has
-	// to hunt for Twitch's own buried play/unmute controls.
+	// The player is a cross-origin iframe with muted+autoplay. Browser rules let
+	// the parent page TOGGLE MUTE on it (player.setMuted works), but NOT start a
+	// paused player — starting playback needs an in-iframe gesture, so we never
+	// call play() and never cover Twitch's own play button. Instead we offer a
+	// small corner "tap for sound" button that only unmutes; on desktop (muted
+	// autoplay already running) it adds sound instantly, and on mobile (where the
+	// video is usually paused) the user taps Twitch's own visible play button to
+	// start, with our button there to add sound.
 	//
 	// FAIL-SAFE: if the SDK script fails to load or `Twitch.Player` is
 	// unavailable, we fall back to a plain muted+autoplay iframe (the original
@@ -30,13 +33,10 @@
 	);
 
 	// 'loading' — SDK in flight, target div mounted so the player has a home.
-	// 'sdk'     — SDK player created; the tap-to-watch overlay is available.
+	// 'sdk'     — SDK player created; the unmute button is available.
 	// 'fallback'— SDK unavailable; render the plain muted iframe instead.
 	let status = $state<'loading' | 'sdk' | 'fallback'>('loading');
-	// Full-area overlay is shown until the first tap. On mobile muted autoplay
-	// may not start, leaving the player paused behind Twitch's own chrome; the
-	// overlay is our single clean tap target that starts + unmutes in one gesture.
-	let interacted = $state(false);
+	let unmuted = $state(false);
 	let playerEl = $state<HTMLDivElement>();
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	let player: any = null;
@@ -96,15 +96,13 @@
 		};
 	});
 
-	function activate() {
+	function unmute() {
 		if (!player) return;
-		// One user gesture starts everything in place (no reload): play() covers
-		// mobile where muted autoplay never started (harmless no-op on desktop
-		// where it's already playing); setMuted(false)+setVolume add sound.
-		player.play();
+		// Toggle mute on the cross-origin player (allowed from the parent). No
+		// play() — starting a paused cross-origin player needs an in-iframe gesture.
 		player.setMuted(false);
 		player.setVolume(0.5);
-		interacted = true;
+		unmuted = true;
 	}
 </script>
 
@@ -122,23 +120,21 @@
 			<div bind:this={playerEl} class="player-target"></div>
 		{/if}
 
-		{#if status === 'sdk' && !interacted}
-			<button
-				class="tap-overlay"
-				onclick={activate}
-				aria-label="Tap to watch the live stream with sound"
-			>
-				<span class="tap-inner">
-					<span class="tap-icon" aria-hidden="true">
-						<svg viewBox="0 0 24 24" width="30" height="30">
-							<path fill="currentColor" d="M8 5v14l11-7z" />
-						</svg>
-					</span>
-					<span class="tap-label">tap to watch with sound</span>
-				</span>
+		{#if status === 'sdk' && !unmuted}
+			<!-- Small corner control: unmutes only, never covers Twitch's own center
+			     play button or control bar. -->
+			<button class="sound-btn" onclick={unmute} aria-label="Tap for sound">
+				<svg viewBox="0 0 24 24" width="15" height="15" aria-hidden="true">
+					<path
+						fill="currentColor"
+						d="M3 9v6h4l5 5V4L7 9H3zm13.5 3a4.5 4.5 0 0 0-2.5-4.03v8.06A4.5 4.5 0 0 0 16.5 12zM14 3.23v2.06a7 7 0 0 1 0 13.42v2.06A9 9 0 0 0 14 3.23z"
+					/>
+				</svg>
+				<span>tap for sound</span>
 			</button>
 		{/if}
 	</div>
+
 	<div
 		class="lcd-hud pointer-events-none absolute inset-x-0 top-0 z-40 flex items-center justify-between p-2 text-[0.6rem] tracking-[0.18em] md:p-3 md:text-xs"
 	>
@@ -211,67 +207,52 @@
 			opacity: 0.35;
 		}
 	}
-	/* Full-area tap target over the whole video — one clean control of ours that
-	   sits above Twitch's cluttered chrome and starts + unmutes in a single tap.
-	   Sampler/LCD aesthetic: darkened video, amber glowing play prompt. */
-	.tap-overlay {
+	/* Small unmute control, pinned to the top-right corner just under the HUD so
+	   it clears Twitch's center play button and its bottom control bar. Sampler/
+	   LCD aesthetic: amber, glowing, monospace. */
+	.sound-btn {
 		position: absolute;
-		inset: 0;
+		top: 30px;
+		right: 8px;
 		z-index: 30;
 		pointer-events: auto;
-		display: grid;
-		place-items: center;
-		width: 100%;
-		height: 100%;
-		margin: 0;
-		padding: 0;
-		border: 0;
-		cursor: pointer;
-		/* Fairly opaque so Twitch's own chrome (Follow/Subscribe/play) is masked and
-		   our prompt reads as the single thing to tap. */
-		background: radial-gradient(
-			ellipse at center,
-			rgba(6, 8, 9, 0.82) 0%,
-			rgba(6, 8, 9, 0.95) 100%
-		);
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+		padding: 4px 10px;
+		border: 1px solid rgba(255, 163, 64, 0.7);
+		border-radius: 999px;
+		background: rgba(6, 8, 9, 0.82);
 		color: #ffa340;
 		font-family: var(--font-jersey);
-		text-shadow:
-			0 0 6px rgba(255, 140, 26, 0.6),
-			0 0 12px rgba(255, 140, 26, 0.3);
-		transition: background 0.15s ease;
-	}
-	.tap-overlay:hover {
-		background: radial-gradient(ellipse at center, rgba(6, 8, 9, 0.72) 0%, rgba(6, 8, 9, 0.9) 100%);
-	}
-	.tap-inner {
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		gap: 12px;
-		padding: 0 16px;
-		text-align: center;
-	}
-	.tap-icon {
-		display: grid;
-		place-items: center;
-		width: 64px;
-		height: 64px;
-		padding-left: 4px; /* optically center the play triangle */
-		border: 2px solid rgba(255, 163, 64, 0.85);
-		border-radius: 50%;
-		background: rgba(6, 8, 9, 0.55);
+		font-size: 0.7rem;
+		letter-spacing: 0.14em;
+		text-transform: uppercase;
+		white-space: nowrap;
+		cursor: pointer;
+		text-shadow: 0 0 6px rgba(255, 140, 26, 0.5);
 		box-shadow:
 			0 0 0 1px rgba(0, 0, 0, 0.4),
-			0 0 22px rgba(255, 140, 26, 0.4),
-			inset 0 0 16px rgba(255, 140, 26, 0.2);
+			0 0 14px rgba(255, 140, 26, 0.35);
+		transition:
+			background 0.15s ease,
+			box-shadow 0.15s ease,
+			transform 0.05s ease;
 	}
-	.tap-overlay:active .tap-icon {
+	.sound-btn:hover {
+		background: rgba(16, 22, 29, 0.92);
+		box-shadow:
+			0 0 0 1px rgba(0, 0, 0, 0.4),
+			0 0 20px rgba(255, 140, 26, 0.55);
+	}
+	.sound-btn:active {
 		transform: translateY(1px);
 	}
-	.tap-label {
-		font-size: 0.95rem;
-		letter-spacing: 0.16em;
-		text-transform: uppercase;
+	@media (min-width: 768px) {
+		.sound-btn {
+			top: 40px;
+			padding: 5px 12px;
+			font-size: 0.78rem;
+		}
 	}
 </style>

--- a/src/lib/TwitchEmbed.svelte
+++ b/src/lib/TwitchEmbed.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+	// Live Twitch player that stands in for the hero sampler screen while the
+	// waterhousestudios stream is on air. Mirrors the embed pattern used on the
+	// /radio page: autoplay requires `muted=true`, and Twitch needs every host
+	// domain declared as a `parent` (localhost included for local preview).
+	const parents = ['waterhousestudios.nl', 'localhost'];
+	const embedSrc =
+		`https://player.twitch.tv/?channel=waterhousestudios&muted=true&` +
+		parents.map((p) => `parent=${p}`).join('&');
+
+	let { title = undefined, viewers = undefined }: { title?: string; viewers?: number } = $props();
+</script>
+
+<div class="lcd relative w-full overflow-hidden rounded">
+	<div class="embed-frame">
+		<iframe
+			src={embedSrc}
+			title="Waterhouse Studios live stream"
+			allowfullscreen
+			allow="autoplay; fullscreen"
+			style="position:absolute;top:0;left:0;width:100%;height:100%;border:0;"
+		></iframe>
+	</div>
+	<div
+		class="lcd-hud pointer-events-none absolute inset-x-0 top-0 z-20 flex items-center justify-between p-2 text-[0.6rem] tracking-[0.18em] md:p-3 md:text-xs"
+	>
+		<span class="flex items-center gap-1.5">
+			<span class="led-live"></span>
+			<span>LIVE</span>
+		</span>
+		{#if title}
+			<span class="lcd-title truncate">{title}</span>
+		{/if}
+		{#if viewers != null}
+			<span>{viewers} 👁</span>
+		{/if}
+	</div>
+</div>
+
+<style>
+	/* Match the sampler LCD housing so the swap is seamless. */
+	.lcd {
+		background: radial-gradient(ellipse at center, #11161d 0%, #060809 100%);
+		border: 1.5px solid #000;
+		box-shadow:
+			inset 0 0 0 1px rgba(255, 154, 60, 0.05),
+			0 0 0 2px rgba(0, 0, 0, 0.1);
+	}
+	/* 16:9 responsive box — fills the .screen cell like the sampler video does. */
+	.embed-frame {
+		position: relative;
+		width: 100%;
+		padding-top: 56.25%;
+	}
+	.lcd-hud {
+		color: #ffa340;
+		font-family: var(--font-jersey);
+		text-shadow:
+			0 0 4px rgba(255, 140, 26, 0.7),
+			0 0 8px rgba(255, 140, 26, 0.3);
+		background: linear-gradient(180deg, rgba(0, 0, 0, 0.55) 0%, rgba(0, 0, 0, 0) 100%);
+	}
+	.lcd-title {
+		max-width: 55%;
+	}
+	.led-live {
+		display: inline-block;
+		width: 8px;
+		height: 8px;
+		border-radius: 50%;
+		background: #ff3b30;
+		box-shadow:
+			0 0 6px rgba(255, 59, 48, 0.9),
+			0 0 12px rgba(255, 59, 48, 0.5);
+		animation: live-pulse 1.4s ease-in-out infinite;
+	}
+	@keyframes live-pulse {
+		0%,
+		100% {
+			opacity: 1;
+		}
+		50% {
+			opacity: 0.35;
+		}
+	}
+</style>

--- a/src/lib/TwitchEmbed.svelte
+++ b/src/lib/TwitchEmbed.svelte
@@ -1,10 +1,18 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
+
 	// Live Twitch player that stands in for the hero sampler screen while the
-	// stream is on air. Mirrors the embed pattern used on the /radio page:
-	// autoplay requires `muted=true`, and Twitch needs every host domain declared
-	// as a `parent` (localhost included for local preview). `parent` is the host
-	// domain, not the channel, so it stays fixed while `channel` follows the
-	// status payload.
+	// stream is on air. `parent` is the host domain (not the channel), so it
+	// stays fixed while `channel` follows the status payload.
+	//
+	// Chrome blocks *unmuted* autoplay, so the player starts muted+autoplay. To
+	// offer sound we use the Twitch Player JS SDK: `player.setMuted(false)` called
+	// inside a user click gesture is allowed, and — unlike swapping the iframe
+	// `src` — it unmutes the *existing* stream without reloading/reconnecting.
+	//
+	// FAIL-SAFE: if the SDK script fails to load or `Twitch.Player` is
+	// unavailable, we fall back to a plain muted iframe (the original embed), so
+	// the feature can never break the hero.
 	let {
 		channel = undefined,
 		title = undefined,
@@ -12,21 +20,113 @@
 	}: { channel?: string; title?: string; viewers?: number } = $props();
 
 	const parents = ['waterhousestudios.nl', 'localhost'];
+	const resolvedChannel = $derived(channel || 'waterhousestudios');
+
+	// Plain muted, autoplaying iframe used as the fail-safe fallback.
 	const embedSrc = $derived(
-		`https://player.twitch.tv/?channel=${channel || 'waterhousestudios'}&muted=true&` +
+		`https://player.twitch.tv/?channel=${resolvedChannel}&muted=true&autoplay=true&` +
 			parents.map((p) => `parent=${p}`).join('&')
 	);
+
+	// 'loading' — SDK in flight, target div mounted so the player has a home.
+	// 'sdk'     — SDK player created; the unmute overlay is available.
+	// 'fallback'— SDK unavailable; render the plain muted iframe instead.
+	let status = $state<'loading' | 'sdk' | 'fallback'>('loading');
+	let muted = $state(true);
+	let playerEl = $state<HTMLDivElement>();
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	let player: any = null;
+
+	const SDK_SRC = 'https://player.twitch.tv/js/embed/v1.js';
+
+	function loadTwitchSdk(): Promise<void> {
+		return new Promise((resolve, reject) => {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const T = (window as any).Twitch;
+			if (T && T.Player) {
+				resolve();
+				return;
+			}
+			const existing = document.querySelector<HTMLScriptElement>('script[data-twitch-embed]');
+			if (existing) {
+				existing.addEventListener('load', () => resolve());
+				existing.addEventListener('error', () => reject(new Error('twitch sdk failed')));
+				return;
+			}
+			const s = document.createElement('script');
+			s.src = SDK_SRC;
+			s.async = true;
+			s.dataset.twitchEmbed = 'true';
+			s.addEventListener('load', () => resolve());
+			s.addEventListener('error', () => reject(new Error('twitch sdk failed')));
+			document.head.appendChild(s);
+		});
+	}
+
+	onMount(() => {
+		let cancelled = false;
+		loadTwitchSdk()
+			.then(() => {
+				if (cancelled) return;
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				const T = (window as any).Twitch;
+				if (!T || !T.Player || !playerEl) {
+					status = 'fallback';
+					return;
+				}
+				player = new T.Player(playerEl, {
+					channel: resolvedChannel,
+					parent: parents,
+					muted: true,
+					autoplay: true,
+					width: '100%',
+					height: '100%'
+				});
+				status = 'sdk';
+			})
+			.catch(() => {
+				if (!cancelled) status = 'fallback';
+			});
+		return () => {
+			cancelled = true;
+		};
+	});
+
+	function unmute() {
+		if (!player) return;
+		// The video is already playing (muted autoplay), so this click only needs
+		// to add sound — unmute the existing stream in place, no reload, no play().
+		player.setMuted(false);
+		player.setVolume(0.5);
+		muted = false;
+	}
 </script>
 
 <div class="lcd relative w-full overflow-hidden rounded">
 	<div class="embed-frame">
-		<iframe
-			src={embedSrc}
-			title="Waterhouse Studios live stream"
-			allowfullscreen
-			allow="autoplay; fullscreen"
-			style="position:absolute;top:0;left:0;width:100%;height:100%;border:0;"
-		></iframe>
+		{#if status === 'fallback'}
+			<iframe
+				src={embedSrc}
+				title="Waterhouse Studios live stream"
+				allowfullscreen
+				allow="autoplay; fullscreen"
+				style="position:absolute;top:0;left:0;width:100%;height:100%;border:0;"
+			></iframe>
+		{:else}
+			<div bind:this={playerEl} class="player-target"></div>
+		{/if}
+
+		{#if status === 'sdk' && muted}
+			<button class="unmute-btn" onclick={unmute} aria-label="Tap to unmute the live stream">
+				<svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true">
+					<path
+						fill="currentColor"
+						d="M3 9v6h4l5 5V4L7 9H3zm13.5 3a4.5 4.5 0 0 0-2.5-4.03v8.06A4.5 4.5 0 0 0 16.5 12zM14 3.23v2.06a7 7 0 0 1 0 13.42v2.06A9 9 0 0 0 14 3.23z"
+					/>
+				</svg>
+				<span>tap to unmute</span>
+			</button>
+		{/if}
 	</div>
 	<div
 		class="lcd-hud pointer-events-none absolute inset-x-0 top-0 z-20 flex items-center justify-between p-2 text-[0.6rem] tracking-[0.18em] md:p-3 md:text-xs"
@@ -59,6 +159,16 @@
 		width: 100%;
 		padding-top: 56.25%;
 	}
+	/* SDK mounts its <iframe> inside here; make it fill the 16:9 box. */
+	.player-target {
+		position: absolute;
+		inset: 0;
+	}
+	.player-target :global(iframe) {
+		width: 100%;
+		height: 100%;
+		border: 0;
+	}
 	.lcd-hud {
 		color: #ffa340;
 		font-family: var(--font-jersey);
@@ -89,5 +199,44 @@
 		50% {
 			opacity: 0.35;
 		}
+	}
+	/* Unmute affordance in the sampler/LCD aesthetic — amber, glowing, monospace. */
+	.unmute-btn {
+		position: absolute;
+		left: 50%;
+		bottom: 12px;
+		transform: translateX(-50%);
+		z-index: 30;
+		pointer-events: auto;
+		display: inline-flex;
+		align-items: center;
+		gap: 8px;
+		padding: 8px 16px;
+		border: 1.5px solid rgba(255, 163, 64, 0.7);
+		border-radius: 999px;
+		background: rgba(6, 8, 9, 0.82);
+		color: #ffa340;
+		font-family: var(--font-jersey);
+		font-size: 0.8rem;
+		letter-spacing: 0.14em;
+		text-transform: uppercase;
+		cursor: pointer;
+		text-shadow: 0 0 6px rgba(255, 140, 26, 0.5);
+		box-shadow:
+			0 0 0 1px rgba(0, 0, 0, 0.4),
+			0 0 16px rgba(255, 140, 26, 0.35);
+		transition:
+			background 0.15s ease,
+			box-shadow 0.15s ease,
+			transform 0.05s ease;
+	}
+	.unmute-btn:hover {
+		background: rgba(16, 22, 29, 0.92);
+		box-shadow:
+			0 0 0 1px rgba(0, 0, 0, 0.4),
+			0 0 22px rgba(255, 140, 26, 0.55);
+	}
+	.unmute-btn:active {
+		transform: translateX(-50%) translateY(1px);
 	}
 </style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -25,6 +25,7 @@
 	import { Confetti } from 'svelte-confetti';
 	import { scale } from 'svelte/transition';
 	import { quintOut } from 'svelte/easing';
+	import { env } from '$env/dynamic/public';
 
 	const galleryImages = [
 		'event_1.jpg',
@@ -58,13 +59,18 @@
 	// non-OK response, or missing `live: true` leaves `live` false and shows the
 	// existing sampler screen. Re-checks every 60s so a mid-session stream appears
 	// without a manual refresh.
-	const STREAM_STATUS_URL = 'https://twitch-api.waterhousestudios.nl/streams/status';
+	//
+	// Endpoint is overridable via PUBLIC_STREAM_STATUS_URL so we can point at a
+	// local backend during testing; unset (prod / GitHub Pages) => prod URL. The
+	// env is read inside checkStream (client-only, via $effect) rather than at
+	// module scope, since $env/dynamic/public can't be read during prerender.
+	const DEFAULT_STREAM_STATUS_URL = 'https://twitch-api.waterhousestudios.nl/streams/status';
 	let live = $state(false);
-	let streamInfo = $state<{ title?: string; viewers?: number } | null>(null);
+	let streamInfo = $state<{ title?: string; viewers?: number; channel?: string } | null>(null);
 
 	async function checkStream() {
 		try {
-			const res = await fetch(STREAM_STATUS_URL);
+			const res = await fetch(env.PUBLIC_STREAM_STATUS_URL || DEFAULT_STREAM_STATUS_URL);
 			if (!res.ok) {
 				live = false;
 				streamInfo = null;
@@ -73,7 +79,7 @@
 			const data = await res.json();
 			if (data && data.live === true) {
 				live = true;
-				streamInfo = { title: data.title, viewers: data.viewers };
+				streamInfo = { title: data.title, viewers: data.viewers, channel: data.channel };
 			} else {
 				live = false;
 				streamInfo = null;
@@ -519,7 +525,11 @@
 		</div>
 		<div class="screen flex flex-col gap-2">
 			{#if live}
-				<TwitchEmbed title={streamInfo?.title} viewers={streamInfo?.viewers} />
+				<TwitchEmbed
+					channel={streamInfo?.channel}
+					title={streamInfo?.title}
+					viewers={streamInfo?.viewers}
+				/>
 			{:else}
 				{@render screen()}
 			{/if}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -523,7 +523,7 @@
 		<div class="buttons flex flex-col gap-2 md:hidden">
 			{@render mainButtons()}
 		</div>
-		<div class="screen flex flex-col gap-2">
+		<div class="screen flex flex-col gap-2" class:screen-live={live}>
 			{#if live}
 				<TwitchEmbed
 					channel={streamInfo?.channel}
@@ -533,7 +533,7 @@
 			{:else}
 				{@render screen()}
 			{/if}
-			<div class="hidden h-full grid-cols-2 gap-2 md:grid md:text-4xl xl:text-7xl">
+			<div class="screen-buttons hidden h-full grid-cols-2 gap-2 md:grid md:text-4xl xl:text-7xl">
 				{@render mainButtons()}
 			</div>
 		</div>
@@ -1643,6 +1643,22 @@
 
 	.screen {
 		grid-area: screen;
+	}
+
+	/* When the stream is live the Twitch embed renders at its true 16:9 aspect
+	   (see TwitchEmbed's .embed-frame). By default flexbox vertically compresses
+	   it — the studios/ateliers block below claims height via h-full — which
+	   letterboxes the player. So on desktop (the buttons block is hidden on
+	   mobile) stop the embed from shrinking and let the buttons block surrender
+	   exactly the extra height the 16:9 player needs, keeping a legible floor.
+	   Gated on .screen-live so the offline sampler layout is unchanged. */
+	@media (min-width: 768px) {
+		.screen-live > :global(.lcd) {
+			flex: none;
+		}
+		.screen-live > .screen-buttons {
+			min-height: 2.75rem;
+		}
 	}
 
 	.buttons {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -12,6 +12,7 @@
 	import ModalVideo from '$lib/modal/ModalVideo.svelte';
 	import Nav from '$lib/Nav.svelte';
 	import SpeakerGrate from '$lib/SpeakerGrate.svelte';
+	import TwitchEmbed from '$lib/TwitchEmbed.svelte';
 	import Seo from '$lib/seo/Seo.svelte';
 	import JsonLd from '$lib/seo/JsonLd.svelte';
 	import SiteFooter from '$lib/SiteFooter.svelte';
@@ -51,6 +52,43 @@
 	const onOpenJoin = () => (isModalOpen = 'join');
 
 	const comingSoon = () => toast.success('Coming soon!');
+
+	// Hero screen swaps to a live Twitch player only when the backend explicitly
+	// reports the stream is on air. Fail-safe by construction: any error,
+	// non-OK response, or missing `live: true` leaves `live` false and shows the
+	// existing sampler screen. Re-checks every 60s so a mid-session stream appears
+	// without a manual refresh.
+	const STREAM_STATUS_URL = 'https://twitch-api.waterhousestudios.nl/streams/status';
+	let live = $state(false);
+	let streamInfo = $state<{ title?: string; viewers?: number } | null>(null);
+
+	async function checkStream() {
+		try {
+			const res = await fetch(STREAM_STATUS_URL);
+			if (!res.ok) {
+				live = false;
+				streamInfo = null;
+				return;
+			}
+			const data = await res.json();
+			if (data && data.live === true) {
+				live = true;
+				streamInfo = { title: data.title, viewers: data.viewers };
+			} else {
+				live = false;
+				streamInfo = null;
+			}
+		} catch {
+			live = false;
+			streamInfo = null;
+		}
+	}
+
+	$effect(() => {
+		checkStream();
+		const id = setInterval(checkStream, 60_000);
+		return () => clearInterval(id);
+	});
 
 	const drumSounds = [
 		'MM Snare 1 copy.wav',
@@ -480,7 +518,11 @@
 			{@render mainButtons()}
 		</div>
 		<div class="screen flex flex-col gap-2">
-			{@render screen()}
+			{#if live}
+				<TwitchEmbed title={streamInfo?.title} viewers={streamInfo?.viewers} />
+			{:else}
+				{@render screen()}
+			{/if}
 			<div class="hidden h-full grid-cols-2 gap-2 md:grid md:text-4xl xl:text-7xl">
 				{@render mainButtons()}
 			</div>


### PR DESCRIPTION
## What

When the **waterhousestudios** Twitch stream is live, the hero "screen" cell renders an embedded live Twitch player instead of the sampler LCD. When offline (the default), the existing sampler screen shows unchanged.

## How it works

- New `src/lib/TwitchEmbed.svelte` reuses the `/radio` embed pattern: muted autoplay, `parent=waterhousestudios.nl` + `parent=localhost`, in a 16:9 responsive box styled to match the sampler LCD housing. Optionally surfaces `title` / `viewers` in the LCD aesthetic.
- `+page.svelte` fetches `https://twitch-api.waterhousestudios.nl/streams/status` on mount (via `$effect`) and re-checks every 60s.
- **Fail-safe by construction:** `live` defaults `false` and only flips `true` on an explicit `{ "live": true }` response. Any fetch failure, non-OK status, or missing field keeps `live = false` and shows the sampler. The embed is never rendered when the stream is off.
- Branch point is the single `{@render screen()}` call site inside the `.screen` grid cell.

Depends on the companion `GET /streams/status` endpoint on the `waterhouse-twitch-overlay` backend. Until it ships, the fetch fails and the page fails safe to the sampler.

## Verification

- `bun run build` succeeds; prerendered `index.html` contains the sampler (`screen.mp4`) and **zero** Twitch iframes, confirming the embed is absent by default.
- Client bundle contains the embed + status URL (renders when `live` flips true) and both `parent` domains.
- No secrets added — the iframe needs only `channel` + `parent`; the endpoint returns public data.

Task: waterhouse-landing-16

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0118ady6gmsqcuqp2WrD3Ssg